### PR TITLE
Check for nullish milliseconds (fixes CRIBL-26468)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/src/locale.js
+++ b/src/locale.js
@@ -528,6 +528,7 @@ function parseSeconds(d, string, i) {
 
 function parseMilliseconds(d, string, i) {
   var n = numberRe.exec(string.slice(i, i + 3));
+  if (!n) return -1;
   var val = n[0];
   if(val.length < 3) { // add any missing trailing 0s 
     val = n[0] + '0'.repeat(3 - val.length);

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -210,6 +210,7 @@ tape("timeParse(\"%L\")(date) parses milliseconds", function(test) {
   test.deepEqual(p("432"), date.local(1900, 0, 1, 0, 0, 0, 432));
   test.deepEqual(p("42"), date.local(1900, 0, 1, 0, 0, 0, 420));
   test.deepEqual(p("4"), date.local(1900, 0, 1, 0, 0, 0, 400));
+  test.deepEqual(p(""), null);
   test.end();
 });
 
@@ -224,6 +225,7 @@ tape("timeParse(\"%f\")(date) parses microseconds", function(test) {
   test.deepEqual(p("432"), date.local(1900, 0, 1, 0, 0, 0, 432));
   test.deepEqual(p("42"), date.local(1900, 0, 1, 0, 0, 0, 420));
   test.deepEqual(p("4"), date.local(1900, 0, 1, 0, 0, 0, 400));
+  test.deepEqual(p(""), null);
   test.end();
 });
 


### PR DESCRIPTION
This PR fixes the `parseMilliseconds` function by adding a proper null check. Before, we were assuming the timestamp string did always contain milliseconds. If that's not the case, the function throws and causes operations to fail (ie this could crash ts extraction/event-breaking in Stream).

If `parseMilliseconds` can't find milliseconds, `-1` is returned. This is in sync with what all the `parseX` functions in this file do when they encounter missing parts.